### PR TITLE
serach lib/pulseaudio to find libpulseaudiocommon*.so in aarch64 hook ld

### DIFF
--- a/scripts/hooks/aarch64_to_arm_userspace.sh
+++ b/scripts/hooks/aarch64_to_arm_userspace.sh
@@ -77,7 +77,7 @@ if [[ "$PROJECT" == "Amlogic-ng" && "$ARCH" == aarch64 ]] ; then
 
 	LD64_SRC1="${LAKKA_DIR}/${LAKKA_BUILD_SUBDIR}/toolchain/aarch64-libreelec-linux-gnueabi/sysroot/usr/lib/"
 	LD64_SRC2="${LAKKA_DIR}/${LAKKA_BUILD_SUBDIR}/toolchain/aarch64-libreelec-linux-gnueabi/lib64/"
-	TARG_DIR="${ADDON_DIR}/lib/ ${ADDON_DIR}/bin/ ${SRC_EXTRA} ${LD64_SRC1} ${LD64_SRC2} ${ADDON_DIR}/usr/lib/libretro/"
+	TARG_DIR="${ADDON_DIR}/lib/ ${ADDON_DIR}/bin/ ${SRC_EXTRA} ${LD64_SRC1} ${LD64_SRC1}/pulseaudio/ ${LD64_SRC2} ${ADDON_DIR}/usr/lib/libretro/"
 	echo -e "\tCreating lib64 directory"
 	DEST_DIR="${ADDON_DIR}/lib/lib64/"
 	mkdir -p "$DEST_DIR"


### PR DESCRIPTION
When aarch64 hook searchs for libpulseaudio*.so dependencies, it can not find libaudiocommon, because it is stored under lib/pulseaudio/ folder. Therefore it is necessary to search this folder explicitly to find the dependencies, if not the executed binary throws error: can not find shared library libpulseaudiocommon*.so